### PR TITLE
Upgrade to 1.19.2

### DIFF
--- a/common/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
+++ b/common/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
@@ -1,13 +1,12 @@
 package xyz.nucleoid.disguiselib.impl.mixin;
 
 import com.mojang.authlib.GameProfile;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.Packet;
+import net.minecraft.network.PacketCallbacks;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket;
@@ -78,14 +77,14 @@ public abstract class ServerPlayNetworkHandlerMixin_Disguiser {
      * @param packet packet being sent
      */
     @Inject(
-            method = "sendPacket(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V",
+            method = "sendPacket(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/network/ClientConnection;send(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V"
+                    target = "Lnet/minecraft/network/ClientConnection;send(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V"
             ),
             cancellable = true
     )
-    private void disguiseEntity(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> listener, CallbackInfo ci) {
+    private void disguiseEntity(Packet<?> packet, PacketCallbacks callbacks, CallbackInfo ci) {
         if(!this.disguiselib$skipCheck) {
             World world = this.player.getEntityWorld();
             Entity entity = null;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
-minecraft_version=1.19
-yarn_mappings=1.19+build.4
-loader_version=0.14.8
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.1
+loader_version=0.14.9
 
 #Fabric api
-fabric_version=0.57.0+1.19
+fabric_version=0.59.0+1.19.2
 
 #Forge
-forge_version=41.0.87
+forge_version=43.0.8
 forge_enabled=true
 
 # Mod Properties


### PR DESCRIPTION
Since 1.19.1 `sendPacket()` uses `PacketCallbacks` parameter instead of `GenericFutureListener`. This resulted in a mixin injection failure.