### PR TITLE
Fix #38

### DIFF
--- a/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
+++ b/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
@@ -83,9 +83,9 @@ public abstract class ServerPlayNetworkHandlerMixin_Disguiser extends ServerComm
                 if(original != null && ((EntityDisguise) original).isDisguised()) {
                     Entity disguised = ((EntityDisguise) original).getDisguiseEntity();
                     if(disguised != null) {
+                        remove.run();
                         ((DisguiseUtils) original).updateTrackedData();
-                        List<DataTracker.SerializedEntry<?>> trackedValues = disguised.getDataTracker().getChangedEntries();
-                        ((EntityTrackerUpdateS2CPacketAccessor) packet).setTrackedValues(trackedValues);
+                        add.accept(new EntityTrackerUpdateS2CPacket(entityId, disguised.getDataTracker().getChangedEntries()));
                     }
                 }
             }

--- a/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
+++ b/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java
@@ -73,7 +73,8 @@ public abstract class ServerPlayNetworkHandlerMixin_Disguiser extends ServerComm
                         trackedValues.add(fakeInvisibleFlag);
                     }
                 }
-                ((EntityTrackerUpdateS2CPacketAccessor) packet).setTrackedValues(trackedValues);
+                remove.run();
+                add.accept(new EntityTrackerUpdateS2CPacket(entityId, trackedValues));
             } else if(!((EntityDisguise) this.player).hasTrueSight()) {
                 // Fixing "wrong data" client issue (#1)
                 // Just prevents the client from spamming the log

--- a/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/accessor/EntityTrackerUpdateS2CPacketAccessor.java
+++ b/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/accessor/EntityTrackerUpdateS2CPacketAccessor.java
@@ -1,19 +1,12 @@
 package xyz.nucleoid.disguiselib.impl.mixin.accessor;
 
-import net.minecraft.entity.data.DataTracker;
-import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.List;
+import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 
 @Mixin(EntityTrackerUpdateS2CPacket.class)
 public interface EntityTrackerUpdateS2CPacketAccessor {
     @Accessor("id")
     int getEntityId();
-
-    @Mutable
-    @Accessor("trackedValues")
-    void setTrackedValues(List<DataTracker.SerializedEntry<?>> trackedValues);
 }


### PR DESCRIPTION
# Start

I can't understand why problem occurred too.
This code was looks greatly works.

https://github.com/NucleoidMC/DisguiseLib/blob/c03f521c8a3e24e1055237e6d79b88226af11d22/src/main/java/xyz/nucleoid/disguiselib/impl/mixin/ServerPlayNetworkHandlerMixin_Disguiser.java#L86-L88

And I don't know how my solution is fixing this issue.

# Debug

## My debug code

```java
System.out.println("TO: " + this.player.getName());
List<SerializedEntry<?>> trackedValuesPrev = entityTrackerUpdateS2CPacket.trackedValues();
System.out.println("prev");
for (var entry : trackedValuesPrev) {
	System.out.println(entry.id() + " = " + entry.value());
}

//
// ▲ Print original values
// ▼ Original Code
//

((DisguiseUtils) original).updateTrackedData();
List<DataTracker.SerializedEntry<?>> trackedValues = disguised.getDataTracker().getChangedEntries();
((EntityTrackerUpdateS2CPacketAccessor) packet).setTrackedValues(trackedValues);
List<SerializedEntry<?>> trackedValuesNext = entityTrackerUpdateS2CPacket.trackedValues();

//
// ▲ Original Code
// ▼ Print changed values
//

System.out.println("next");
for (var entry : trackedValuesNext) {
	System.out.println(entry.id() + " = " + entry.value());
}

var buffer = new RegistryByteBuf(Unpooled.buffer(), server.getRegistryManager());
EntityTrackerUpdateS2CPacket.CODEC.encode(buffer, entityTrackerUpdateS2CPacket);

var builder = new StringBuilder();
for (var i = 0; i < buffer.readableBytes(); i++) {
	if (i > 0) builder.append(",");
	builder.append(String.format("%02X", buffer.getByte(i)));
}
System.out.println(builder);
```

## Printed message

Printed message looks no problem.
But the client was disconnected with below message.
```
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: TO: literal{Player622}
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: prev
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: 9 = 20.0
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: 17 = 127
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: next
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: 5 = true
[20:01:02][Server thread/INFO](Minecraft)[STDOUT]: 38,05,08,01,FF
[20:01:02][Server thread/INFO][(Minecraft)Player622 lost connection: Disconnected
[20:01:02][Server thread/INFO][(Minecraft)Player622 left the game
```

# Client disconnected with this messages

```
[20:01:02] [Render thread/ERROR] (Minecraft) Failed to handle packet EntityTrackerUpdateS2CPacket[id=56, packedItems=[SerializedEntry[id=9, serializer=net.minecraft.entity.data.TrackedDataHandler$$Lambda/0x00000008009b6560@7e48974f, value=20.0], SerializedEntry[id=17, serializer=net.minecraft.entity.data.TrackedDataHandler$$Lambda/0x00000008009b6560@1c2608e3, value=127]]], disconnecting
java.lang.IllegalStateException: Invalid entity data item type for field 9 on entity ChestBoatEntity['Acacia Boat with Chest'/56, l='ClientLevel', x=86.50, y=65.00, z=24.50]: old=1(class java.lang.Integer), new=20.0(class java.lang.Float)
	at knot/net.minecraft.entity.data.DataTracker.copyToFrom(DataTracker.java:124) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.entity.data.DataTracker.writeUpdatedEntries(DataTracker.java:113) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.client.network.ClientPlayNetworkHandler.onEntityTrackerUpdate(ClientPlayNetworkHandler.java:563) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket.apply(EntityTrackerUpdateS2CPacket.java:53) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket.apply(EntityTrackerUpdateS2CPacket.java:20) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.network.NetworkThreadUtils.method_11072(NetworkThreadUtils.java:27) ~[minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.util.thread.ThreadExecutor.executeTask(ThreadExecutor.java:144) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.util.thread.ReentrantThreadExecutor.executeTask(ReentrantThreadExecutor.java:24) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.util.thread.ThreadExecutor.runTask(ThreadExecutor.java:118) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.util.thread.ThreadExecutor.runTasks(ThreadExecutor.java:107) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1295) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.client.MinecraftClient.run(MinecraftClient.java:930) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at knot/net.minecraft.client.main.Main.main(Main.java:240) [minecraft-merged-c22ab19269-1.21.4-net.fabricmc.yarn.1_21_4.1.21.4+build.1-v2.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) [fabric-loader-0.16.9.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.16.9.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.16.9.jar:?]
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) [dev-launch-injector-0.2.1+build.8.jar:?]
[20:01:02] [Render thread/WARN] (Minecraft) Client disconnected with reason: Network Protocol Error
```

# Solution I found

It was fixed create a new EntityTrackerUpdateS2CPacket instance Instead of replace `trackedValues`.
In my test, it works for me.

## Before

```java
((DisguiseUtils) original).updateTrackedData();
List<DataTracker.SerializedEntry<?>> trackedValues = disguised.getDataTracker().getChangedEntries();
((EntityTrackerUpdateS2CPacketAccessor) packet).setTrackedValues(trackedValues);
```

## After

```java
((DisguiseUtils) original).updateTrackedData();
List<DataTracker.SerializedEntry<?>> trackedValues = disguised.getDataTracker().getChangedEntries();
remove.run();
add.accept(new EntityTrackerUpdateS2CPacket(entityId, trackedValues);
```