### PR TITLE
Add minecraft version suffix to mod version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = JavaVersion.VERSION_21
 archivesBaseName = rootProject.archives_base_name
 version = rootProject.mod_version
 group = rootProject.maven_group
-
+version += "+" + rootProject.minecraft_version
 repositories {
 	maven {
 		url 'https://jitpack.io'
@@ -28,10 +28,10 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 processResources {
-	inputs.property "version", project.version
+	inputs.property "version", version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version
+		expand "version": version
 	}
 }
 


### PR DESCRIPTION
This fixes the issue of version overlapping whenever DisguiseLib gets updated to a new minecraft version without bumping the mod's version